### PR TITLE
fix missing dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -43,6 +43,7 @@ use inc::Module::Install;
 			Modern::Perl  0
 			Module::Load::Conditional  0 
 			Parse::RecDescent  0
+			SUPER  0
 			Term::ReadLine::Gnu  0
 			Text::Diff  0
 			Text::Format  0


### PR DESCRIPTION
I got following error when I installed this package.

```
Can't locate SUPER.pm in @INC (you may need to install the SUPER module) (@INC contains: /home/syohei/.cpanm/work/1395285418.25557/Audio-Nama-1.113/inc /home/syohei/.cpanm/work/1395285418.25557/Audio-Nama-1.113/blib/lib /home/syohei/.cpanm/work/1395285418.25557/Audio-Nama-1.113/blib/arch /home/syohei/.plenv/versions/5.18.1/lib/perl5/site_perl/5.18.1/i686-linux-thread-multi /home/syohei/.plenv/versions/5.18.1/lib/perl5/site_perl/5.18.1 /home/syohei/.plenv/versions/5.18.1/lib/perl5/5.18.1/i686-linux-thread-multi /home/syohei/.plenv/versions/5.18.1/lib/perl5/5.18.1 .) at /home/syohei/.cpanm/work/1395285418.25557/Audio-Nama-1.113/blib/lib/Audio/Nama/Track.pm line 1078.
BEGIN failed--compilation aborted at /home/syohei/.cpanm/work/1395285418.25557/Audio-Nama-1.113/blib/lib/Audio/Nama/Track.pm line 1078.
Compilation failed in require at /home/syohei/.cpanm/work/1395285418.25557/Audio-Nama-1.113/blib/lib/Audio/Nama.pm line 92.
BEGIN failed--compilation aborted at /home/syohei/.cpanm/work/1395285418.25557/Audio-Nama-1.113/blib/lib/Audio/Nama.pm line 92.
Compilation failed in require at t/12_nama.t line 2.
BEGIN failed--compilation aborted at t/12_nama.t line 2.
t/12_nama.t ..... 
Dubious, test returned 2 (wstat 512, 0x200)
No subtests run 
```
